### PR TITLE
fixing: redundant prefixes for markdown files and regex for code smells

### DIFF
--- a/smellmv2/content_extractors/output_smell_details_extractor.py
+++ b/smellmv2/content_extractors/output_smell_details_extractor.py
@@ -44,7 +44,11 @@ class OutputSmellExtractor():
                 with open(file_path, 'r', encoding='utf-8') as file:
                     content = file.read()
                     
-                    matches = re.findall(r'- Code smell name - (.+)', content)
+                    # Try bold pattern first: - **Code smell name:** or - **Code smell name**:  
+                    matches = re.findall(r'- \*\*Code smell name:?\*\*:?\s*(.+)', content, re.IGNORECASE)
+                    # If no matches, try simple pattern: - Code smell name -
+                    if not matches:
+                        matches = re.findall(r'- Code smell name - (.+)', content, re.IGNORECASE)
                     main_file_name = file_name.split('_')[-1]
                     code_smells = [match.strip() for match in matches]
 
@@ -53,14 +57,8 @@ class OutputSmellExtractor():
     
 
 if __name__ == "__main__":
-    
-    # Path to your file
     folder_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), '../../', 'java_single_file_code_smells/gpt-4o')
     smellExtractor = OutputSmellExtractor(output_path=folder_path, code_smells=constants.CODE_SMELLS)
-    
     detected_code_smells = smellExtractor.process_documents()
     print(detected_code_smells)
-    print("all matcher")
-    print(len(detected_code_smells))
-    # matched_smells = smellExtractor.match_with_smell_list(detected_code_smells, threshold=90)
-    # print(matched_smells)
+    print("Total files processed:", len(detected_code_smells))

--- a/smellmv2/output/save_data.py
+++ b/smellmv2/output/save_data.py
@@ -13,14 +13,14 @@ class SaveData():
     def save_file(self, data):
         
         for key, value in data.items():
-            # Replace any / or \ in the key with _
-            safe_filename = key.replace('/', '_').replace('\\', '_')
+            # Extract just the filename from the path (handle full paths or relative paths)
+            filename = os.path.basename(key)
             
-            if '.' in safe_filename:
-                filename_base = safe_filename.rsplit('.', 1)[0]  # Get the name without extension
+            if '.' in filename:
+                filename_base = filename.rsplit('.', 1)[0]  # Get the name without extension
                 safe_filename = f"{filename_base}.md"
             else:
-                safe_filename = f"{safe_filename}.md"
+                safe_filename = f"{filename}.md"
             
             # Create the full path to the file
             file_path = os.path.join(self.output_dir_path, safe_filename)

--- a/smellmv2/output/test_output.py
+++ b/smellmv2/output/test_output.py
@@ -61,7 +61,11 @@ class TestOutput:
     def __merge_dataframes(self, df1, df2):
         # Merge two DataFrames on 'File Name' column
         try:
-            merged_df = pd.merge(df1, df2, on='File Name', how='inner')
+            # Drop result columns from previous test runs if they exist
+            result_columns = ['Detected Code Smells', 'True Positives', 'False Positives', 'False Negatives', 'True Negatives']
+            df1_clean = df1.drop(columns=[col for col in result_columns if col in df1.columns], errors='ignore')
+            
+            merged_df = pd.merge(df1_clean, df2, on='File Name', how='inner')
             merged_df['Expected Code Smells'] = merged_df['Expected Code Smells'].apply(self.__format_row_smell)
             merged_df['Detected Code Smells'] = merged_df['Detected Code Smells'].apply(self.__format_row_smell)
             return merged_df


### PR DESCRIPTION
Try bold pattern first: - **Code smell name:** or - **Code smell name**:
If no matches, try simple pattern: - Code smell name -